### PR TITLE
PKG-13150: update pyfiglet to 1.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyfiglet" %}
-{% set version = "0.8.post1" %}
+{% set version = "1.0.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c6c2321755d09267b438ec7b936825a4910fec696292139e664ca8670e103639
+  sha256: db9c9940ed1bf3048deff534ed52ff2dafbbc2cd7610b17bb5eca1df6d4278ef
 
 build:
   number: 0


### PR DESCRIPTION
pyfiglet 1.0.4

**Destination channel:** defaults

### Links

- [PKG-13150](https://anaconda.atlassian.net/browse/PKG-13150)
- [Upstream repository](https://github.com/pwaller/pyfiglet)
- [Upstream changelog/diff](https://github.com/pwaller/pyfiglet/compare/v0.8.post1...v1.0.4)

### Explanation of changes:

- Update pyfiglet from 0.8.post1 to 1.0.4


[PKG-13150]: https://anaconda.atlassian.net/browse/PKG-13150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ